### PR TITLE
Add new logical operations, improve flag handling, and address type safety

### DIFF
--- a/anvil/include/instructions.h
+++ b/anvil/include/instructions.h
@@ -11,6 +11,8 @@ typedef enum
     OP_DIV,
     OP_INC,
     OP_DEC,
+    OP_AND,
+    OP_OR,
     OP_XOR,
     OP_CMP,
     OP_JMP,

--- a/axiom/src/lexer.c
+++ b/axiom/src/lexer.c
@@ -22,7 +22,7 @@ Lexer* init_lexer(char* source)
 void advance(Lexer* lexer)
 {
     lexer->position++;
-    if (lexer->position >= strlen(lexer->source))
+    if (lexer->position >= (int)strlen(lexer->source))
         lexer->current_char = '\0';
     else
     {
@@ -40,7 +40,7 @@ void advance(Lexer* lexer)
 char peek(Lexer* lexer)
 {
     int peek_pos = lexer->position + 1;
-    if (peek_pos >= strlen(lexer->source))
+    if (peek_pos >= (int)strlen(lexer->source))
         return '\0';
     return lexer->source[peek_pos];
 }

--- a/axiom/src/main.c
+++ b/axiom/src/main.c
@@ -1,6 +1,6 @@
 #include <stdio.h>
 
-int main(int argc, char *argv[])
+int main()
 {
     printf("Hello, World!\n");
 }


### PR DESCRIPTION
### Virtual Machine Enhancements (`anvil`)

* **New Logical Operations**: Added support for `OP_AND` and `OP_OR` instructions in the `OpCode enum` in `instructions.h` and implemented their behavior in `execute_instruction`. These operations use both assembly (if enabled) and fallback C implementations.
* **Flag Updates**: Modified `update_flags` to handle new operations (`OP_AND`, `OP_OR`, and others) and ensure correct flag calculations for arithmetic and logical instructions. Added specific cases for logical operations to update only `ZF` and `SF` flags.
* **Instruction Execution Improvements**: Enhanced `execute_instruction` to include calls to `update_flags` for `OP_INC`, `OP_DEC`, `OP_AND`, `OP_OR`, and `OP_XOR` to ensure accurate CPU flag updates.

### Lexer Improvements (`axiom`)

* **Type Safety**: Updated comparisons in `advance` and `peek` functions to cast `strlen` results to `int`, ensuring compatibility with the `position` variable type.

### Miscellaneous

* **Simplified Main Function**: Removed unused parameters (`argc`, `argv`) from the `main` function in `axiom/src/main.c` for simplicity.