### PR TITLE
Refactor lexer and parser: update token type definitions and add parser initial implementation

### DIFF
--- a/axiom/include/lexer.h
+++ b/axiom/include/lexer.h
@@ -1,9 +1,11 @@
 #ifndef LEXER_H_
 #define LEXER_H_
 
+#include <stdbool.h>
 #include <string.h>
+#include <stdlib.h>
 
-enum token_type {
+typedef enum{
     // keywords
     TOKEN_IF,     // if
     TOKEN_ELSE,   // else
@@ -40,24 +42,22 @@ enum token_type {
     TOKEN_NUMBER,      // number
 
     TOKEN_EOF,
-};
+} TokenType;
 
-struct token {
-    enum token_type type;
+typedef struct {
+    TokenType type;
     char* value;
     int line;
     int column;
-};
-typedef struct token Token;
+} Token;
 
-struct lexer {
+typedef struct {
     char* source;
     int position;
     int line;
     int column;
     char current_char;
-};
-typedef struct lexer Lexer;
+} Lexer;
 
 Lexer* init_lexer(char* source);
 void advance(Lexer* lexer);

--- a/axiom/include/parser.h
+++ b/axiom/include/parser.h
@@ -1,0 +1,15 @@
+#ifndef PARSER_H_
+#define PARSER_H_
+
+#include "lexer.h"
+
+typedef struct {
+    const char* str;
+    size_t pos;
+} Parser;
+
+void parser_init(Parser* parser, const char* str);
+bool is_end_of_line(Parser* parser);
+bool parse_keyword(Parser* parser, TokenType expected);
+
+#endif // PARSER_H_

--- a/axiom/src/parser.c
+++ b/axiom/src/parser.c
@@ -1,0 +1,15 @@
+#include "parser.h"
+
+void parser_init(Parser* parser, const char* str) {
+    parser->str = str;
+    parser->pos = 0;
+}
+
+bool is_end_of_line(Parser* parser) {
+    return parser->str[parser->pos] == '\0' ||
+           parser->str[parser->pos] == '\n' || parser->str[parser->pos] == ';';
+}
+
+bool parse_keyword(Parser* parser, TokenType expected) {
+
+}


### PR DESCRIPTION
This pull request introduces changes to the lexer and parser components of the `axiom` project, focusing on refactoring the lexer data structures, adding a new parser header and implementation, and improving type definitions for better clarity and maintainability.

### Lexer Refactoring:
* Refactored `enum token_type` to `TokenType` using `typedef` for improved readability and consistency.
* Refactored `struct token` and `struct lexer` to `Token` and `Lexer` using `typedef`, simplifying their usage throughout the codebase.

### Parser Implementation:
* Added a new `parser.h` header file defining the `Parser` struct and parser-related functions (`parser_init`, `is_end_of_line`, `parse_keyword`).
* Implemented the `parser_init` and `is_end_of_line` functions in `parser.c`, providing basic functionality for initializing and handling the parser.