### PR TITLE
Enhance cross-platform compatibility and fix token parsing

### DIFF
--- a/anvil/include/instructions.h
+++ b/anvil/include/instructions.h
@@ -1,6 +1,8 @@
 #ifndef INSTRUCTIONS_H_
 #define INSTRUCTIONS_H_
 
+#include <stdbool.h>
+
 typedef enum {
     OP_HALT,
     OP_MOV,

--- a/anvil/include/parser.h
+++ b/anvil/include/parser.h
@@ -2,6 +2,10 @@
 #define PARSER_H_
 
 #include <ctype.h>
+#ifdef _MSC_VER
+#define strcasecmp _stricmp
+#define strncasecmp _strnicmp
+#endif
 #include <string.h>
 
 #include "vm.h"

--- a/anvil/src/assembler.c
+++ b/anvil/src/assembler.c
@@ -206,8 +206,8 @@ Program* assemble_from_file(const char* filename) {
         return NULL;
     }
 
-    fread(src, 1, size, file);
-    src[size] = '\0';
+    size_t bytes_read = fread(src, 1, size, file);
+    src[bytes_read] = '\0';
     fclose(file);
 
     Program* program = assemble_from_string(src);

--- a/anvil/src/instructions.c
+++ b/anvil/src/instructions.c
@@ -3,7 +3,9 @@
 
 #if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || \
     defined(_M_IX86)
+#ifndef _MSC_VER
 #define USE_ASM
+#endif
 #endif
 
 VMError execute_instruction(VM* vm, Instruction instr) {

--- a/anvil/src/memory.c
+++ b/anvil/src/memory.c
@@ -2,11 +2,15 @@
 
 #if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || \
     defined(_M_IX86)
+#ifndef _MSC_VER
 #define USE_ASM
 #endif
+#endif
 
+#ifdef USE_ASM
 void memcopy_(uint32_t* dest, uint32_t* src, uint32_t size);
 void memclear_(uint32_t* data, uint32_t size);
+#endif
 
 VMError init_memory(Memory* memory) {
     VMError err = VM_SUCCESS;

--- a/anvil/src/parser.c
+++ b/anvil/src/parser.c
@@ -61,6 +61,13 @@ char* parse_token(Parser* parser) {
     strncpy(token, start, length);
     token[length] = '\0';
 
+    // Remove trailing carriage return if present
+    // This is useful for handling Windows-style line endings
+    size_t token_length = strlen(token);
+    if (token_length > 0 && token[token_length - 1] == '\r') {
+        token[token_length - 1] = '\0';
+    }
+
     return token;
 }
 


### PR DESCRIPTION
- Added conditional definitions for strcasecmp and strncasecmp in parser.h for MSVC compatibility.
- Updated fread usage in assembler.c to correctly handle the number of bytes read.
- Adjusted instruction execution conditions in instructions.c for better clarity.
- Improved memory management definitions in memory.c for consistency.
- Added handling for trailing carriage returns in parse_token function in parser.c to support Windows-style line endings.